### PR TITLE
71 fix pint dictionary

### DIFF
--- a/tests/finite_element_problem/test_linear_cylinder.py
+++ b/tests/finite_element_problem/test_linear_cylinder.py
@@ -11,12 +11,12 @@ from fenicsxconcrete.unit_registry import ureg
 
 
 def simple_setup(p: Parameters, displacement: float, sensor: Sensor, bc_setting: pint.Quantity) -> None:
-    parameters = Parameters()  # using the current default values
-
+    parameters = {}
     parameters["log_level"] = "WARNING" * ureg("")
     parameters["bc_setting"] = bc_setting
     parameters["mesh_density"] = 10 * ureg("")
-    parameters = parameters + p
+
+    parameters.update(p)
 
     experiment = CompressionCylinder(parameters)
 
@@ -35,8 +35,7 @@ def simple_setup(p: Parameters, displacement: float, sensor: Sensor, bc_setting:
 @pytest.mark.parametrize("degree", [1, 2])
 @pytest.mark.parametrize("bc_setting", ["fixed", "free"])
 def test_force_response(bc_setting: int, degree: int, dim: str) -> None:
-    p = Parameters()  # using the current default values
-
+    p = {}
     p["E"] = 1023 * ureg("MPa")
     p["nu"] = 0.0 * ureg("")
     p["radius"] = 0.006 * ureg("m")
@@ -47,6 +46,7 @@ def test_force_response(bc_setting: int, degree: int, dim: str) -> None:
     p["degree"] = degree * ureg("")
 
     sensor = ReactionForceSensorBottom()
+
     measured = simple_setup(p, displacement, sensor, p["bc_setting"])
 
     result = None
@@ -55,12 +55,12 @@ def test_force_response(bc_setting: int, degree: int, dim: str) -> None:
     elif dim == 3:
         result = p["E"] * np.pi * p["radius"] ** 2 * displacement / p["height"]
 
-    assert measured == pytest.approx(result.magnitude, 0.01)
+    assert measured == pytest.approx(result.to_base_units().magnitude, 0.01)
 
 
 @pytest.mark.parametrize("bc_setting", ["fixed", "free"])
 def test_errors_dimensions(bc_setting: str) -> None:
-    p = Parameters()  # using the current default values
+    p = {}
     p["E"] = 1023 * ureg("MPa")
     p["nu"] = 0.0 * ureg("")
     p["radius"] = 0.006 * ureg("m")
@@ -77,7 +77,7 @@ def test_errors_dimensions(bc_setting: str) -> None:
 
 
 def test_errors_bc_setting() -> None:
-    p = Parameters()  # using the current default values
+    p = {}
     p["E"] = 1023 * ureg("MPa")
     p["nu"] = 0.0 * ureg("")
     p["radius"] = 0.006 * ureg("m")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+import pytest
 from pint import UnitRegistry
 
 from fenicsxconcrete.helper import Parameters
@@ -29,3 +30,19 @@ def test_parameter_dic_functions() -> None:
     # testing if adding None to dictionary works
     new = parameters + None
     assert new is parameters
+
+
+def test_parameter_dic_update() -> None:
+    parameters = Parameters()
+
+    # testing that update still requires a pint object
+    p_wo_pint = {"length": 0.006}
+    with pytest.raises(AssertionError):
+        parameters.update(p_wo_pint)
+
+    # testing that conversion to base units works with update
+    length = 6000
+    p_with_pint = {"length": length * ureg("mm")}
+    parameters.update(p_with_pint)
+
+    assert parameters["length"].magnitude == length / 1000


### PR DESCRIPTION
I wanted to define the input parameters as a normal dictionary as I think its more user friendly and intuitive.
The cylinder tests are using the input values to define the expected result, the result needs to be converted to base units to make the comparison as magnitude work.
The parameter dict is working perfectly!!!