### PR TITLE
105 citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,8 +20,10 @@ authors:
     orcid: 'https://orcid.org/0009-0006-4444-2494'
   - given-names: Erik
     family-names: Tamsen
+    orcid: 'https://orcid.org/0000-0002-6359-0146'
   - given-names: Divyansh
     family-names: Tyagi
+    orcid: 'https://orcid.org/0009-0005-2483-3589'
   - given-names: Jörg F.
     family-names: Unger
     orcid: 'https://orcid.org/0000-0003-0035-0951'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,10 @@ authors:
     orcid: 'https://orcid.org/0009-0003-2522-2179'
   - given-names: Philipp
     family-names: Diercks
+    orcid: 'https://orcid.org/0000-0003-4495-4423'
   - given-names: Annika
     family-names: Robens-Radermacher
+    orcid: 'https://orcid.org/0000-0001-9653-6085'
   - given-names: Sjard Mathis
     family-names: Rosenbusch
     orcid: 'https://orcid.org/0009-0006-4444-2494'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,7 @@ type: software
 authors:
   - given-names: Daniel
     family-names: Andrés Arcones
+    orcid: 'https://orcid.org/0009-0003-2522-2179'
   - given-names: Philipp
     family-names: Diercks
   - given-names: Annika

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: ' FenicsXConcrete '
+message: Please cite this software using these metadata.
+type: software
+authors:
+  - given-names: Daniel
+    family-names: Andrés Arcones
+  - given-names: Philipp
+    family-names: Diercks
+  - given-names: Annika
+    family-names: Robens-Radermacher
+  - given-names: Sjard Mathis
+    family-names: Rosenbusch
+    orcid: 'https://orcid.org/0009-0006-4444-2494'
+  - given-names: Erik
+    family-names: Tamsen
+  - given-names: Divyansh
+    family-names: Tyagi
+  - given-names: Jörg F.
+    family-names: Unger
+    orcid: 'https://orcid.org/0000-0003-0035-0951'
+repository-code: 'https://github.com/BAMresearch/FenicsXConcrete'
+license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,5 +27,8 @@ authors:
   - given-names: Jörg F.
     family-names: Unger
     orcid: 'https://orcid.org/0000-0003-0035-0951'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.7780757
 repository-code: 'https://github.com/BAMresearch/FenicsXConcrete'
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: ' FenicsXConcrete '
+title: FenicsXConcrete
 message: Please cite this software using these metadata.
 type: software
 authors:
@@ -31,4 +31,7 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.7780757
 repository-code: 'https://github.com/BAMresearch/FenicsXConcrete'
+abstract: >-
+  This software uses FEniCSx for FEM simulations of
+  structural mechanics problems.
 license: MIT


### PR DESCRIPTION
Adds a `CITATION.cff` file. It contains:
1. All names in alphabetical order
2. ORCIDS of all developers
3. The zenodo doi for all releases

This should be enough for now.