### PR TITLE
Set python version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: fenicsxconcrete
 channels:
   - conda-forge
 dependencies:
+  - python>=3.10
   # runtime
   - fenics-dolfinx
   - scipy
@@ -26,4 +27,4 @@ dependencies:
   - isort
   - pip
   - pip:
-      - -e .
+    - -e .


### PR DESCRIPTION
Setting a minimal python version of `python>=3.10` fixes the issue with the environment as described in https://github.com/BAMresearch/FenicsXConcrete/issues/121